### PR TITLE
Suggested changes to your joomla-cms PR 4872

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1583,7 +1583,7 @@ class JoomlaInstallerScript
 		// Setup the adapter for the indexer.
 		$format = $db->name;
 
-		if ($format == 'mysqli')
+		if ($format == 'mysqli' || $format == 'pdomysql')
 		{
 			$format = 'mysql';
 		}
@@ -1602,6 +1602,7 @@ class JoomlaInstallerScript
 				return;
 			}
 
+			$utf8mb4IsSupported = $this->serverClaimsUtf8mb4Support($db->name);
 
 			// Execute the queries
 			foreach ($queries as $query)
@@ -1612,7 +1613,7 @@ class JoomlaInstallerScript
 				{
 					try
 					{
-						if (!$this->serverClaimsUtf8mb4Support($db->name))
+						if (!utf8mb4IsSupported)
 						{
 							$query = str_replace('utf8mb4', 'utf8', $query);
 						}
@@ -1652,6 +1653,10 @@ class JoomlaInstallerScript
 			case 'mysqli':
 				$client_version = mysqli_get_client_info();
 				$server_version = $db->getVersion();
+				break;
+			case 'pdomysql';
+				$client_version = $db->getOption(PDO::ATTR_CLIENT_VERSION);
+				$server_version = $db->getOption(PDO::ATTR_SERVER_VERSION);
 				break;
 			default:
 				$client_version = false;

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1596,21 +1596,33 @@ class JoomlaInstallerScript
 			$fileContents = @file_get_contents($fileName);
 			$queries = $db->splitSql($fileContents);
 
+			if (count($queries) == 0)
+			{
+				// No queries to process
+				return;
+			}
+
+
 			// Execute the queries
 			foreach ($queries as $query)
 			{
-				try
-				{
-					if (!$this->serverClaimsUtf8mb4Support($db->name))
-					{
-						$query = str_replace('utf8mb4', 'utf8', $query);
-					}
+				$query = trim($query);
 
-					$db->setQuery($query)->execute();
-				}
-				catch (RuntimeException $e)
+				if ($query != '' && $query{0} != '#')
 				{
-					JFactory::getApplication()->enqueueMessage(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $e->getCode(), $e->getMessage()));
+					try
+					{
+						if (!$this->serverClaimsUtf8mb4Support($db->name))
+						{
+							$query = str_replace('utf8mb4', 'utf8', $query);
+						}
+
+						$db->setQuery($query)->execute();
+					}
+					catch (RuntimeException $e)
+					{
+						JFactory::getApplication()->enqueueMessage(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $e->getCode(), $e->getMessage()));
+					}
 				}
 			}
 		}

--- a/administrator/components/com_admin/sql/utf8mb4/mysql/3.5.0-2015-07-01.sql
+++ b/administrator/components/com_admin/sql/utf8mb4/mysql/3.5.0-2015-07-01.sql
@@ -5,6 +5,8 @@ ALTER TABLE `#__menu` DROP KEY `idx_client_id_parent_id_alias_language`, ADD UNI
 
 ALTER TABLE `#__redirect_links` DROP KEY `idx_link_old`, ADD UNIQUE KEY `idx_link_old` (`old_url`(191));
 
+ALTER TABLE `#__menu` DROP  KEY `idx_path`, ADD KEY `idx_path` (`path`(191));
+
 ALTER TABLE `#__session` MODIFY `session_id` varchar(191) NOT NULL DEFAULT '';
 
 ALTER TABLE `#__user_keys` MODIFY `series` varchar(191) NOT NULL;
@@ -119,7 +121,7 @@ ALTER TABLE `#__finder_filters` CHANGE COLUMN `data` `data` TEXT NOT NULL;
 ALTER TABLE `#__finder_filters` CHANGE COLUMN `params` `params` MEDIUMTEXT;
 ALTER TABLE `#__languages` CHANGE COLUMN `metakey` `metakey` TEXT NOT NULL;
 ALTER TABLE `#__languages` CHANGE COLUMN `metadesc` `metadesc` TEXT NOT NULL;
-ALTER TABLE `#__menu` CHANGE COLUMN `params` `params` TEXT NOT NULL;
+ALTER TABLE `#__menu` CHANGE COLUMN `params` `params` TEXT NOT NULL COMMENT 'JSON encoded data for the menu item.';
 ALTER TABLE `#__messages` CHANGE COLUMN `message` `message` TEXT NOT NULL;
 ALTER TABLE `#__modules` CHANGE COLUMN `content` `content` TEXT NOT NULL;
 ALTER TABLE `#__modules` CHANGE COLUMN `params` `params` TEXT NOT NULL;
@@ -130,7 +132,7 @@ ALTER TABLE `#__newsfeeds` CHANGE COLUMN `metadata` `metadata` TEXT NOT NULL;
 ALTER TABLE `#__newsfeeds` CHANGE COLUMN `description` `description` TEXT NOT NULL;
 ALTER TABLE `#__newsfeeds` CHANGE COLUMN `images` `images` TEXT NOT NULL;
 ALTER TABLE `#__overrider` CHANGE COLUMN `string` `string` TEXT NOT NULL;
-ALTER TABLE `#__session` CHANGE COLUMN `data` `data` MEDIUMTEXT NOT NULL;
+ALTER TABLE `#__session` CHANGE COLUMN `data` `data` MEDIUMTEXT;
 ALTER TABLE `#__tags` CHANGE COLUMN `description` `description` MEDIUMTEXT NOT NULL;
 ALTER TABLE `#__tags` CHANGE COLUMN `params` `params` TEXT NOT NULL;
 ALTER TABLE `#__tags` CHANGE COLUMN `images` `images` TEXT NOT NULL;

--- a/administrator/components/com_admin/sql/utf8mb4/mysql/3.5.0-2015-07-01.sql
+++ b/administrator/components/com_admin/sql/utf8mb4/mysql/3.5.0-2015-07-01.sql
@@ -151,7 +151,3 @@ ALTER TABLE `#__update_sites` CHANGE COLUMN `location` `location` TEXT NOT NULL;
 ALTER TABLE `#__users` CHANGE COLUMN `params` `params` TEXT NOT NULL;
 ALTER TABLE `#__user_notes` CHANGE COLUMN `body` `body` TEXT NOT NULL;
 ALTER TABLE `#__user_profiles` CHANGE COLUMN `profile_value` `profile_value` TEXT NOT NULL;
-
--- Drop obsolete indexes
-ALTER TABLE `#__contentitem_tag_map` DROP INDEX `idx_tag`;
-ALTER TABLE `#__contentitem_tag_map` DROP INDEX `idx_type`;


### PR DESCRIPTION
This fixes:

```
Message

Database query failed (error # 1091): Can't DROP 'idx_tag'; check that column/key exists SQL=-- Drop obsolete indexes ALTER TABLE `osvlt_contentitem_tag_map` DROP INDEX `idx_tag`;

Database query failed (error # 1091): Can't DROP 'idx_type'; check that column/key exists SQL=ALTER TABLE `osvlt_contentitem_tag_map` DROP INDEX `idx_type`;

Database query failed (error # 0): SQL=

Installation of the file was successful.
```

It also makes the schema when updating the same as when installing.
