### PR TITLE
Eliminate unneeded column resizing

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.5.0-2015-07-01.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.0-2015-07-01.sql
@@ -1,15 +1,10 @@
 -- Index and field changes to cater for UTF-8 Multibyte (utf8mb4)
-ALTER TABLE `#__menu` DROP KEY `idx_client_id_parent_id_alias_language`, ADD UNIQUE KEY `idx_client_id_parent_id_alias_language` (`client_id`,`parent_id`,`alias`(191),`language`);
-ALTER TABLE `#__redirect_links` DROP KEY `idx_link_old`, ADD UNIQUE KEY `idx_link_old` (`old_url`(191));
+ALTER TABLE `#__menu` DROP KEY `idx_client_id_parent_id_alias_language`, ADD KEY `idx_client_id_parent_id_alias_language` (`client_id`,`parent_id`,`alias`(191),`language`);
+ALTER TABLE `#__redirect_links` DROP KEY `idx_link_old`, ADD KEY `idx_link_old` (`old_url`(191));
 ALTER TABLE `#__menu` DROP  KEY `idx_path`, ADD KEY `idx_path` (`path`(191));
 ALTER TABLE `#__session` MODIFY `session_id` varchar(191) NOT NULL DEFAULT '';
 ALTER TABLE `#__user_keys` MODIFY `series` varchar(191) NOT NULL;
 ALTER TABLE `#__update_sites_extensions` ENGINE=InnoDB;
-ALTER TABLE `#__banners` MODIFY `alias` varchar(191) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '';
-ALTER TABLE `#__categories` MODIFY `alias` varchar(191) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '';
-ALTER TABLE `#__contact_details` MODIFY `alias` varchar(191) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '';
-ALTER TABLE `#__content` MODIFY `alias` varchar(191) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '';
-ALTER TABLE `#__menu` MODIFY `alias` varchar(191) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'The SEF alias of the menu item.';
-ALTER TABLE `#__newsfeeds` MODIFY `alias` varchar(191) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '';
-ALTER TABLE `#__tags` MODIFY `alias` varchar(191) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '';
-ALTER TABLE `#__ucm_content` MODIFY `core_alias` varchar(191) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '';
+ALTER TABLE `#__categories` DROP KEY `idx_alias`, ADD KEY `idx_alias` (`alias`(191));
+ALTER TABLE `#__tags` DROP KEY `idx_alias`, ADD KEY `idx_alias` (`alias`(191));
+ALTER TABLE `#__ucm_content` DROP KEY `idx_alias`, ADD KEY `idx_alias` (`core_alias`(191));

--- a/administrator/components/com_admin/sql/utf8mb4/mysql.sql
+++ b/administrator/components/com_admin/sql/utf8mb4/mysql.sql
@@ -70,14 +70,14 @@ ALTER TABLE `#__user_usergroup_map` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb
 ALTER TABLE `#__viewlevels` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 
 -- Convert utf8_bin collated columns to utf8mb4_bin collation
-ALTER TABLE `#__banners` MODIFY `alias` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
-ALTER TABLE `#__categories` MODIFY `alias` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
-ALTER TABLE `#__contact_details` MODIFY `alias` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
-ALTER TABLE `#__content` MODIFY `alias` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
-ALTER TABLE `#__menu` MODIFY `alias` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL COMMENT 'The SEF alias of the menu item.';
-ALTER TABLE `#__newsfeeds` MODIFY `alias` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
-ALTER TABLE `#__tags` MODIFY `alias` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
-ALTER TABLE `#__ucm_content` MODIFY `core_alias` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
+ALTER TABLE `#__banners` MODIFY `alias` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
+ALTER TABLE `#__categories` MODIFY `alias` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
+ALTER TABLE `#__contact_details` MODIFY `alias` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
+ALTER TABLE `#__content` MODIFY `alias` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
+ALTER TABLE `#__menu` MODIFY `alias` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL COMMENT 'The SEF alias of the menu item.';
+ALTER TABLE `#__newsfeeds` MODIFY `alias` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
+ALTER TABLE `#__tags` MODIFY `alias` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
+ALTER TABLE `#__ucm_content` MODIFY `core_alias` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
 
 -- Convert columns back to their original size
 ALTER TABLE `#__banners` CHANGE COLUMN `description` `description` TEXT NOT NULL;

--- a/administrator/components/com_redirect/controllers/links.php
+++ b/administrator/components/com_redirect/controllers/links.php
@@ -102,10 +102,19 @@ class RedirectControllerLinks extends JControllerAdmin
 		{
 			$model = $this->getModel('Links');
 
-			// Execute the batch process
-			if ($model->batchProcess($batch_urls))
+			// Execute the batch process and retrieve any unprocessed URLs
+			$badUrls = $model->batchProcess($batch_urls);
+
+			if (!empty($badUrls)) {
+				JFactory::getApplication()
+					->enqueueMessage(JText::_('COM_REDIRECT_ERROR_DUPLICATE_OLD_URL') . "<br/>" . implode("<br/>", $badUrls), 'error');
+			}
+
+			$processedUrlCount = count($batch_urls) - count($badUrls);
+
+			if ($processedUrlCount)
 			{
-				$this->setMessage(JText::plural('COM_REDIRECT_N_LINKS_ADDED', count($batch_urls)));
+				$this->setMessage(JText::plural('COM_REDIRECT_N_LINKS_ADDED', $processedUrlCount));
 			}
 		}
 

--- a/administrator/components/com_redirect/tables/link.php
+++ b/administrator/components/com_redirect/tables/link.php
@@ -71,7 +71,14 @@ class RedirectTableLink extends JTable
 			}
 		}
 
-		// Check for duplicates
+		/*
+		 * In the database, old_url is limited to 255 characters.  Trim it down now, so that duplicate
+		 * detection works properly.  We can't rely on the database to detect duplicates using a unique
+		 * key because key lengths are limited to 191 characters in MySQL with the utf8mb4 character set.
+		 * That rules out using unique keys for columns over 191 characters.
+		 */
+		$this->old_url = substr($this->old_url, 0, 255);
+
 		if ($this->old_url == $this->new_url)
 		{
 			$this->setError(JText::_('COM_REDIRECT_ERROR_DUPLICATE_URLS'));

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -108,7 +108,7 @@ CREATE TABLE IF NOT EXISTS `#__banners` (
   `cid` int(11) NOT NULL DEFAULT 0,
   `type` int(11) NOT NULL DEFAULT 0,
   `name` varchar(255) NOT NULL DEFAULT '',
-  `alias` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
+  `alias` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
   `imptotal` int(11) NOT NULL DEFAULT 0,
   `impmade` int(11) NOT NULL DEFAULT 0,
   `clicks` int(11) NOT NULL DEFAULT 0,
@@ -205,7 +205,7 @@ CREATE TABLE IF NOT EXISTS `#__categories` (
   `path` varchar(255) NOT NULL DEFAULT '',
   `extension` varchar(50) NOT NULL DEFAULT '',
   `title` varchar(255) NOT NULL,
-  `alias` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
+  `alias` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
   `note` varchar(255) NOT NULL DEFAULT '',
   `description` mediumtext NOT NULL,
   `published` tinyint(1) NOT NULL DEFAULT 0,
@@ -229,7 +229,7 @@ CREATE TABLE IF NOT EXISTS `#__categories` (
   KEY `idx_checkout` (`checked_out`),
   KEY `idx_path` (`path`),
   KEY `idx_left_right` (`lft`,`rgt`),
-  KEY `idx_alias` (`alias`),
+  KEY `idx_alias` (`alias`(191)),
   KEY `idx_language` (`language`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_general_ci;
 
@@ -254,7 +254,7 @@ INSERT INTO `#__categories` (`id`, `asset_id`, `parent_id`, `lft`, `rgt`, `level
 CREATE TABLE IF NOT EXISTS `#__contact_details` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL DEFAULT '',
-  `alias` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
+  `alias` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
   `con_position` varchar(255) DEFAULT NULL,
   `address` text,
   `suburb` varchar(100) DEFAULT NULL,
@@ -316,7 +316,7 @@ CREATE TABLE IF NOT EXISTS `#__content` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `asset_id` int(10) unsigned NOT NULL DEFAULT 0 COMMENT 'FK to the #__assets table.',
   `title` varchar(255) NOT NULL DEFAULT '',
-  `alias` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
+  `alias` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
   `introtext` mediumtext NOT NULL,
   `fulltext` mediumtext NOT NULL,
   `state` tinyint(3) NOT NULL DEFAULT 0,
@@ -1216,7 +1216,7 @@ CREATE TABLE IF NOT EXISTS `#__menu` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `menutype` varchar(24) NOT NULL COMMENT 'The type of menu this item belongs to. FK to #__menu_types.menutype',
   `title` varchar(255) NOT NULL COMMENT 'The display title of the menu item.',
-  `alias` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL COMMENT 'The SEF alias of the menu item.',
+  `alias` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL COMMENT 'The SEF alias of the menu item.',
   `note` varchar(255) NOT NULL DEFAULT '',
   `path` varchar(1024) NOT NULL COMMENT 'The computed path of the menu item based on the alias field.',
   `link` varchar(1024) NOT NULL COMMENT 'The actually link the menu item refers to.',
@@ -1238,7 +1238,7 @@ CREATE TABLE IF NOT EXISTS `#__menu` (
   `language` char(7) NOT NULL DEFAULT '',
   `client_id` tinyint(4) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `idx_client_id_parent_id_alias_language` (`client_id`,`parent_id`,`alias`(191),`language`),
+  KEY `idx_client_id_parent_id_alias_language` (`client_id`,`parent_id`,`alias`(191),`language`),
   KEY `idx_componentid` (`component_id`,`menutype`,`published`,`access`),
   KEY `idx_menutype` (`menutype`),
   KEY `idx_left_right` (`lft`,`rgt`),
@@ -1426,7 +1426,7 @@ CREATE TABLE IF NOT EXISTS `#__newsfeeds` (
   `catid` int(11) NOT NULL DEFAULT 0,
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(100) NOT NULL DEFAULT '',
-  `alias` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
+  `alias` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
   `link` varchar(200) NOT NULL DEFAULT '',
   `published` tinyint(1) NOT NULL DEFAULT 0,
   `numarticles` int(10) unsigned NOT NULL DEFAULT 1,
@@ -1528,7 +1528,7 @@ CREATE TABLE IF NOT EXISTS `#__redirect_links` (
   `modified_date` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `header` smallint(3) NOT NULL DEFAULT 301,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `idx_link_old` (`old_url`(191)),
+  KEY `idx_link_old` (`old_url`(191)),
   KEY `idx_link_modifed` (`modified_date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_general_ci;
 
@@ -1577,7 +1577,7 @@ CREATE TABLE IF NOT EXISTS `#__tags` (
   `level` int(10) unsigned NOT NULL DEFAULT 0,
   `path` varchar(255) NOT NULL DEFAULT '',
   `title` varchar(255) NOT NULL,
-  `alias` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
+  `alias` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
   `note` varchar(255) NOT NULL DEFAULT '',
   `description` mediumtext NOT NULL,
   `published` tinyint(1) NOT NULL DEFAULT 0,
@@ -1606,7 +1606,7 @@ CREATE TABLE IF NOT EXISTS `#__tags` (
   KEY `idx_checkout` (`checked_out`),
   KEY `idx_path` (`path`),
   KEY `idx_left_right` (`lft`,`rgt`),
-  KEY `idx_alias` (`alias`),
+  KEY `idx_alias` (`alias`(191)),
   KEY `idx_language` (`language`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_general_ci;
 
@@ -1672,7 +1672,7 @@ CREATE TABLE IF NOT EXISTS `#__ucm_content` (
   `core_content_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `core_type_alias` varchar(255) NOT NULL DEFAULT '' COMMENT 'FK to the content types table',
   `core_title` varchar(255) NOT NULL,
-  `core_alias` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
+  `core_alias` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
   `core_body` mediumtext NOT NULL,
   `core_state` tinyint(1) NOT NULL DEFAULT 0,
   `core_checked_out_time` varchar(255) NOT NULL DEFAULT '',
@@ -1704,7 +1704,7 @@ CREATE TABLE IF NOT EXISTS `#__ucm_content` (
   PRIMARY KEY (`core_content_id`),
   KEY `tag_idx` (`core_state`,`core_access`),
   KEY `idx_access` (`core_access`),
-  KEY `idx_alias` (`core_alias`),
+  KEY `idx_alias` (`core_alias`(191)),
   KEY `idx_language` (`core_language`),
   KEY `idx_title` (`core_title`),
   KEY `idx_modified_time` (`core_modified_time`),

--- a/libraries/legacy/table/menu.php
+++ b/libraries/legacy/table/menu.php
@@ -164,6 +164,9 @@ class JTableMenu extends JTableNested
 			return false;
 		}
 
+		// Aliases are truncated to 255 characters in the database.  Truncate it now to assure duplicate detection.
+		$this->alias = substr($this->alias, 0, 255);
+
 		return true;
 	}
 

--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -68,6 +68,14 @@ class PlgSystemRedirect extends JPlugin
 		$uri     = JUri::getInstance();
 		$current = rawurldecode($uri->toString(array('scheme', 'host', 'port', 'path', 'query', 'fragment')));
 
+                /*
+                 * In the database, old_url is limited to 255 characters.  Trim the url down now, so that duplicate
+                 * detection works properly.  We can't rely on the database to detect duplicates using a unique
+                 * key because key lengths are limited to 191 characters in MySQL with the utf8mb4 character set.
+                 * That rules out using unique keys for columns over 191 characters.
+                 */
+                $current = substr($current, 0, 255);
+
 		// Attempt to ignore idiots.
 		if ((strpos($current, 'mosConfig_') !== false) || (strpos($current, '=http://') !== false))
 		{
@@ -89,6 +97,7 @@ class PlgSystemRedirect extends JPlugin
 		if (!$link or ($link->published != 1))
 		{
 			$currRel = rawurldecode($uri->toString(array('path', 'query', 'fragment')));
+                	$currRel = substr($currRel, 0, 255);
 			$query = $db->getQuery(true)
 				->select($db->quoteName('new_url'))
 				->select($db->quoteName('published'))


### PR DESCRIPTION
The shrinking of column sizes could have lead to possible data loss.

Also, remove the UNIQUE qualifier from indexes that are being resized smaller
for holding utf8mb4 data.  The smaller key size may mean that the key is no
longer unique, even though we know the full size key was unique.  Uniqueness is
already enforced by Joomla's code, so there's no need for the database to
enforce it as well.

Also, improve the code that detects duplicate values for those keys where the
UNIQUE qualifier has been removed.
